### PR TITLE
reduces lines of code by using react given types for childrens

### DIFF
--- a/.react-email/src/app/layout.tsx
+++ b/.react-email/src/app/layout.tsx
@@ -9,9 +9,7 @@ export const inter = Inter({
 
 export default function RootLayout({
   children,
-}: {
-  children: React.ReactNode;
-}) {
+}: React.PropsWithChildren ) {
   return (
     <html lang="en">
       <body className="bg-black text-slate-12 font-sans">

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -5,11 +5,8 @@ import { siteConfig } from "@/config/site"
 import { AspectRatio } from "@/components/ui/aspect-ratio"
 import { Icons } from "@/components/icons"
 
-interface AuthLayoutProps {
-  children: React.ReactNode
-}
 
-export default function AuthLayout({ children }: AuthLayoutProps) {
+export default function AuthLayout({ children }: React.PropsWithChildren) {
   return (
     <div className="grid min-h-screen grid-cols-1 overflow-hidden md:grid-cols-3 lg:grid-cols-2">
       <AspectRatio ratio={16 / 9}>

--- a/src/app/(checkout)/cart/layout.tsx
+++ b/src/app/(checkout)/cart/layout.tsx
@@ -3,11 +3,8 @@ import { currentUser } from "@clerk/nextjs"
 
 import { SiteHeader } from "@/components/layouts/site-header"
 
-interface CartLayoutProps {
-  children: React.ReactNode
-}
 
-export default async function CartLayout({ children }: CartLayoutProps) {
+export default async function CartLayout({ children }: React.PropsWithChildren) {
   const user = await currentUser()
 
   if (!user) {

--- a/src/app/(checkout)/checkout/layout.tsx
+++ b/src/app/(checkout)/checkout/layout.tsx
@@ -1,13 +1,10 @@
 import { redirect } from "next/navigation"
 import { currentUser } from "@clerk/nextjs"
 
-interface CheckoutLayoutProps {
-  children: React.ReactNode
-}
 
 export default async function CheckoutLayout({
   children,
-}: CheckoutLayoutProps) {
+}: React.PropsWithChildren) {
   const user = await currentUser()
 
   if (!user) {

--- a/src/app/(dashboard)/dashboard/layout.tsx
+++ b/src/app/(dashboard)/dashboard/layout.tsx
@@ -7,13 +7,10 @@ import { SidebarNav } from "@/components/layouts/sidebar-nav"
 import { SiteFooter } from "@/components/layouts/site-footer"
 import { SiteHeader } from "@/components/layouts/site-header"
 
-interface DashboardLayoutProps {
-  children: React.ReactNode
-}
 
 export default async function DashboardLayout({
   children,
-}: DashboardLayoutProps) {
+}: React.PropsWithChildren) {
   const user = await currentUser()
 
   if (!user) {

--- a/src/app/(dashboard)/dashboard/stores/[storeId]/layout.tsx
+++ b/src/app/(dashboard)/dashboard/stores/[storeId]/layout.tsx
@@ -15,12 +15,12 @@ import { StoreTabs } from "@/components/pagers/store-tabs"
 import { Shell } from "@/components/shells/shell"
 import { getSubscriptionPlanAction } from "@/app/_actions/stripe"
 
-interface StoreLayoutProps {
-  children: React.ReactNode
+type StoreLayoutProps =  React.PropsWithChildren & {
   params: {
     storeId: string
   }
 }
+
 
 export default async function StoreLayout({
   children,

--- a/src/app/(lobby)/layout.tsx
+++ b/src/app/(lobby)/layout.tsx
@@ -3,11 +3,8 @@ import { currentUser } from "@clerk/nextjs"
 import { SiteFooter } from "@/components/layouts/site-footer"
 import { SiteHeader } from "@/components/layouts/site-header"
 
-interface LobbyLayoutProps {
-  children: React.ReactNode
-}
 
-export default async function LobbyLayout({ children }: LobbyLayoutProps) {
+export default async function LobbyLayout({ children }: React.PropsWithChildren ) {
   const user = await currentUser()
 
   return (

--- a/src/app/(lobby)/products/layout.tsx
+++ b/src/app/(lobby)/products/layout.tsx
@@ -1,6 +1,5 @@
-interface ProductsLayoutProps {
-  children: React.ReactNode
-  modal: React.ReactNode
+type ProductsLayoutProps = React.PropsWithChildren & {
+  modal : React.PropsWithChildren
 }
 
 export default function ProductsLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,11 +61,8 @@ export const metadata: Metadata = {
   },
 }
 
-interface RootLayoutProps {
-  children: React.ReactNode
-}
 
-export default function RootLayout({ children }: RootLayoutProps) {
+export default function RootLayout({ children }: React.PropsWithChildren) {
   return (
     <>
       <ClerkProvider>

--- a/src/components/checkout/checkout-shell.tsx
+++ b/src/components/checkout/checkout-shell.tsx
@@ -9,13 +9,12 @@ import { cn } from "@/lib/utils"
 
 // Docs: https://stripe.com/docs/payments/quickstart
 
-interface CheckoutShellProps extends React.HTMLAttributes<HTMLDivElement> {
-  children: React.ReactNode
-  storeStripeAccountId: string
+type CheckoutShellProps = React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>> & {
+  storeStripeAccountId: string,
   paymentIntent: Promise<{
     clientSecret: string | null
   }>
-}
+};
 
 export function CheckoutShell({
   children,

--- a/src/components/layouts/mobile-nav.tsx
+++ b/src/components/layouts/mobile-nav.tsx
@@ -112,8 +112,7 @@ export function MobileNav({ mainNavItems, sidebarNavItems }: MobileNavProps) {
   )
 }
 
-interface MobileLinkProps {
-  children?: React.ReactNode
+type MobileLinkProps = React.PropsWithChildren & {
   href: string
   disabled?: boolean
   segment: string

--- a/src/components/mdx/callout.tsx
+++ b/src/components/mdx/callout.tsx
@@ -4,10 +4,9 @@
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 
-interface CalloutProps {
+type CalloutProps = React.PropsWithChildren & {
   icon?: string
   title?: string
-  children?: React.ReactNode
 }
 
 export function Callout({ title, children, icon, ...props }: CalloutProps) {

--- a/src/components/shells/dialog-shell.tsx
+++ b/src/components/shells/dialog-shell.tsx
@@ -7,9 +7,7 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Icons } from "@/components/icons"
 
-interface DialogShellProps extends React.HTMLAttributes<HTMLDivElement> {
-  children: React.ReactNode
-}
+type DialogShellProps = React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>;
 
 export function DialogShell({
   children,


### PR DESCRIPTION
Earlier interfaces were created for just allowing chlidren to be used, but react has this pre defined type know as PropsWithChildren that already does that for us
as you can check in the below image
![image](https://github.com/sadmann7/skateshop/assets/114667178/21095db6-d8e9-45a9-8c53-8f3b7ef0ab5d)
