### PR TITLE
Changed link href in category subcategories mapping

### DIFF
--- a/src/app/(lobby)/page.tsx
+++ b/src/app/(lobby)/page.tsx
@@ -260,7 +260,7 @@ export default async function IndexPage({ searchParams }: IndexPageProps) {
         ]?.subcategories.map((subcategory) => (
           <Link
             key={subcategory.slug}
-            href={`/categories/${String(productCategories[0]?.title)}/${
+            href={`/categories/${String(subcategory.title)}/${
               subcategory.slug
             }`}
           >


### PR DESCRIPTION
- Updated the href attribute of the Link component to use the subcategory's title instead of the first category's title.


