### PR TITLE
checkProduct in Fetchers/Product.ts exposed DB on New Product Page

### DIFF
--- a/src/components/forms/add-product-form.tsx
+++ b/src/components/forms/add-product-form.tsx
@@ -12,7 +12,7 @@ import { type z } from "zod"
 
 import { getSubcategories } from "@/config/products"
 import { addProduct } from "@/lib/actions/product"
-import { checkProduct } from "@/lib/fetchers/product"
+import { checkProduct } from "@/lib/actions/product"
 import { catchError, isArrayOfFile } from "@/lib/utils"
 import { productSchema } from "@/lib/validations/product"
 import { Button } from "@/components/ui/button"

--- a/src/lib/fetchers/product.ts
+++ b/src/lib/fetchers/product.ts
@@ -11,7 +11,6 @@ import {
   inArray,
   lt,
   lte,
-  not,
   sql,
 } from "drizzle-orm"
 import { stores } from "drizzle/schema"
@@ -119,27 +118,6 @@ export async function getProducts(rawInput: z.infer<typeof getProductsSchema>) {
       : err instanceof z.ZodError
         ? err.issues.map((issue) => issue.message).join("\n")
         : new Error("Unknown error.")
-  }
-}
-
-export async function checkProduct(input: { name: string; id?: number }) {
-  noStore()
-  try {
-    const productWithSameName = await db.query.products.findFirst({
-      columns: {
-        id: true,
-      },
-      where: input.id
-        ? and(not(eq(products.id, input.id)), eq(products.name, input.name))
-        : eq(products.name, input.name),
-    })
-
-    if (productWithSameName) {
-      throw new Error("Product name already taken.")
-    }
-  } catch (err) {
-    console.error(err)
-    return null
   }
 }
 


### PR DESCRIPTION
Moving checkProduct from fetchers to actions because env shouldn't be available to client component. Alternatively use server could be added to fetchers/product.ts.