### PR TITLE
Adding a layout.tsx to the content folder

### DIFF
--- a/src/app/(lobby)/(content)/layout.tsx
+++ b/src/app/(lobby)/(content)/layout.tsx
@@ -1,0 +1,23 @@
+import { currentUser } from "@clerk/nextjs"
+
+import { SiteFooter } from "@/components/layouts/site-footer"
+import { SiteHeader } from "@/components/layouts/site-header"
+
+interface MainLayoutProps
+  extends React.PropsWithChildren<{
+    modal: React.ReactNode
+  }> {}
+
+export default async function MainLayout({ children }: MainLayoutProps) {
+  const user = await currentUser()
+
+  return (
+    <div className="relative flex min-h-screen flex-col">
+      <SiteHeader user={user} />
+      <main className="flex-1">
+        {children}
+      </main>
+      <SiteFooter />
+    </div>
+  )
+}


### PR DESCRIPTION
This is because the navbar is not being added to any of the content grouping of directories. This could alternatively be solved with adding the siteheader to the upper most layout, but given you are adding the siteheader in the layouts of each of the directory groupings, I thought I would match the established pattern.