### PR TITLE
fix: redirect fix from tabs

### DIFF
--- a/src/components/pagers/store-tabs.tsx
+++ b/src/components/pagers/store-tabs.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Link from "next/link"
 import { useRouter, useSelectedLayoutSegment } from "next/navigation"
 import { Tabs, TabsList, TabsTrigger } from "@radix-ui/react-tabs"
 
@@ -65,7 +66,7 @@ export function StoreTabs({ storeId }: StoreTabsProps) {
                 tab.isActive && "text-foreground"
               )}
             >
-              {tab.title}
+              <Link href={tab.href}>{tab.title}</Link>
             </TabsTrigger>
           </div>
         ))}


### PR DESCRIPTION
For dashboard tabs like the store , products, orders , ... there is tab but there is no way of redirection back from any subroute like product/[product_id] - for this we might be editing , or creating new product or something on the sub route we need someway of redirecting back to the product list as we press on the active tab section which is product on our usecase so no one should not have to navigate to other tabs and come back or edit the url just to get the /products tab so that the user can click to product to get to the /product from products/[anysubroutes]