### PR TITLE
fix: 29 Prevent access to sign-in pages when logged in

### DIFF
--- a/src/app/(auth)/signin/[[...signin]]/page.tsx
+++ b/src/app/(auth)/signin/[[...signin]]/page.tsx
@@ -13,6 +13,8 @@ import {
 import { Shell } from "@/components/shell"
 import { OAuthSignIn } from "@/app/(auth)/_components/oauth-signin"
 import { SignInForm } from "@/app/(auth)/_components/signin-form"
+import { redirect } from "next/navigation";
+import { getCachedUser } from "@/lib/queries/user";
 
 export const metadata: Metadata = {
   metadataBase: new URL(env.NEXT_PUBLIC_APP_URL),
@@ -20,7 +22,13 @@ export const metadata: Metadata = {
   description: "Sign in to your account",
 }
 
-export default function SignInPage() {
+export default async function SignInPage() {
+  const user = await getCachedUser();
+
+  if (user) {
+    redirect("/");
+  }
+
   return (
     <Shell className="max-w-lg">
       <Card>

--- a/src/app/(auth)/signin/reset-password/[[...reset-password]]/page.tsx
+++ b/src/app/(auth)/signin/reset-password/[[...reset-password]]/page.tsx
@@ -10,6 +10,8 @@ import {
 } from "@/components/ui/card"
 import { Shell } from "@/components/shell"
 import { ResetPasswordForm } from "@/app/(auth)/_components/reset-password-form"
+import { redirect } from "next/navigation";
+import { getCachedUser } from "@/lib/queries/user";
 
 export const metadata: Metadata = {
   metadataBase: new URL(env.NEXT_PUBLIC_APP_URL),
@@ -17,7 +19,13 @@ export const metadata: Metadata = {
   description: "Enter your email to reset your password",
 }
 
-export default function ResetPasswordPage() {
+export default async function ResetPasswordPage() {
+  const user = await getCachedUser();
+
+  if (user) {
+    redirect("/");
+  }
+  
   return (
     <Shell className="max-w-lg">
       <Card>

--- a/src/app/(auth)/signin/reset-password/confirm/[[...confirm]]/page.tsx
+++ b/src/app/(auth)/signin/reset-password/confirm/[[...confirm]]/page.tsx
@@ -10,6 +10,8 @@ import {
 } from "@/components/ui/card"
 import { Shell } from "@/components/shell"
 import { ResetPasswordConfirmForm } from "@/app/(auth)/_components/reset-password-confirm-form"
+import { redirect } from "next/navigation";
+import { getCachedUser } from "@/lib/queries/user";
 
 export const metadata: Metadata = {
   metadataBase: new URL(env.NEXT_PUBLIC_APP_URL),
@@ -17,7 +19,13 @@ export const metadata: Metadata = {
   description: "Enter your email to reset your password",
 }
 
-export default function ResetPasswordConfirmPage() {
+export default async function ResetPasswordConfirmPage() {
+  const user = await getCachedUser();
+
+  if (user) {
+    redirect("/");
+  }
+  
   return (
     <Shell className="max-w-lg">
       <Card>

--- a/src/app/(auth)/signup/[[...signup]]/page.tsx
+++ b/src/app/(auth)/signup/[[...signup]]/page.tsx
@@ -13,6 +13,8 @@ import {
 import { Shell } from "@/components/shell"
 import { OAuthSignIn } from "@/app/(auth)/_components/oauth-signin"
 import { SignUpForm } from "@/app/(auth)/_components/signup-form"
+import { redirect } from "next/navigation";
+import { getCachedUser } from "@/lib/queries/user";
 
 export const metadata: Metadata = {
   metadataBase: new URL(env.NEXT_PUBLIC_APP_URL),
@@ -20,7 +22,13 @@ export const metadata: Metadata = {
   description: "Sign up for an account",
 }
 
-export default function SignUpPage() {
+export default async function SignUpPage() {
+  const user = await getCachedUser();
+
+  if (user) {
+    redirect("/");
+  }
+  
   return (
     <Shell className="max-w-lg">
       <Card>

--- a/src/app/(auth)/signup/verify-email/[[...verify-email]]/page.tsx
+++ b/src/app/(auth)/signup/verify-email/[[...verify-email]]/page.tsx
@@ -10,6 +10,8 @@ import {
 } from "@/components/ui/card"
 import { Shell } from "@/components/shell"
 import { VerifyEmailForm } from "@/app/(auth)/_components/verify-email-form"
+import { redirect } from "next/navigation";
+import { getCachedUser } from "@/lib/queries/user";
 
 export const metadata: Metadata = {
   metadataBase: new URL(env.NEXT_PUBLIC_APP_URL),
@@ -17,7 +19,13 @@ export const metadata: Metadata = {
   description: "Verify your email address to continue with your sign up",
 }
 
-export default function VerifyEmailPage() {
+export default async function VerifyEmailPage() {
+  const user = await getCachedUser();
+
+  if (user) {
+    redirect("/");
+  }
+  
   return (
     <Shell className="max-w-lg">
       <Card>

--- a/src/app/(auth)/sso-callback/[[...sso-callback]]/page.tsx
+++ b/src/app/(auth)/sso-callback/[[...sso-callback]]/page.tsx
@@ -2,8 +2,16 @@ import { AuthenticateWithRedirectCallback } from "@clerk/nextjs"
 
 import { Icons } from "@/components/icons"
 import { Shell } from "@/components/shell"
+import { redirect } from "next/navigation";
+import { getCachedUser } from "@/lib/queries/user";
 
-export default function SSOCallbackPage() {
+export default async function SSOCallbackPage() {
+  const user = await getCachedUser();
+
+  if (user) {
+    redirect("/");
+  }
+  
   return (
     <Shell className="max-w-lg place-items-center">
       <Icons.spinner className="size-16 animate-spin" aria-hidden="true" />


### PR DESCRIPTION
fixes : https://github.com/sadmann7/skateshop/issues/29
Currently, users can still access the sign-in pages even after they are logged in.

BREAKING CHANGE: none

DEPRECATED: none

Closes: 29
Changelog: fix